### PR TITLE
feat(docusaurus): Add syntax highlighting for Tact and FunC

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -107,7 +107,7 @@ copyright: `
     },
     prism: {
       theme: prismThemes.github,
-      darkTheme: prismThemes.dracula,
+      darkTheme: prismThemes.oneDark,
     },
   } satisfies Preset.ThemeConfig,
 };

--- a/src/theme/prism-func.js
+++ b/src/theme/prism-func.js
@@ -1,0 +1,143 @@
+/**
+ * @file Prism.js definition for FunC
+ * @link https://docs.ton.org/develop/func/overview
+ * @version 0.4.4
+ * @author Novus Nota (https://github.com/novusnota)
+ * @author Nikita Sobolev (https://github.com/sobolevn)
+ * @license MIT
+ */
+(function(Prism) {
+  /** @type {Prism.GrammarValue} */
+  var number = /-?\b(?:\d+|0x[\da-fA-F]+)\b(?![^\.~,;\[\]\(\)\s])/;
+
+  /** @type {Prism.GrammarValue} */
+  var string = [
+    { // multi-line
+      pattern: /"""[\s\S]*?"""[Hhcusa]?/,
+      greedy: true,
+      inside: {
+        // string type
+        'symbol': {
+          pattern: /("""[\s\S]*?""")[Hhcusa]/,
+          lookbehind: true,
+          greedy: true,
+        }
+      },
+    },
+    { // single-line
+      pattern: /"[^\n"]*"[Hhcusa]?/,
+      greedy: true,
+      inside: {
+        // string type
+        'symbol': {
+          pattern: /("[^\n"]*")[Hhcusa]/,
+          lookbehind: true,
+          greedy: true,
+        }
+      },
+    },
+  ];
+
+  /** @type {Prism.GrammarValue} */
+  var operator = /(?:!=|\?|:|%=|%|&=|&|\*=|\*|\+=|\+|->|-=|-|\/%|\/=|\/|<=>|<<=|<<|<=|<|==|=|>>=|>>|>=|>|\^>>=|\^>>|\^=|\^\/=|\^\/|\^%=|\^%|\^|\|=|\||~>>=|~>>|~\/=|~\/|~%|~)(?=\s)/;
+
+  /** @type {RegExp[]} */
+  var var_identifier = [
+    // quoted
+    /`[^`\n]+`/,
+    // plain
+    /[^\.~,;\[\]\(\)\s]+/
+  ];
+
+  /** Prism.js definition for FunC */
+  Prism.languages.func = {
+    'comment': [
+      { // single-line
+        pattern: /;;.*/,
+        lookbehind: true,
+        greedy: true,
+      },
+      { // multi-line, not nested (TODO: nesting)
+        // . isn't used, because it only applies to the single line
+        pattern: /\{-[\s\S]*?(?:-\}|$)/,
+        lookbehind: true,
+        greedy: true,
+      },
+      {
+        // unused variable identifier
+        pattern: /\b_\b(?![^\.~,;\[\]\(\)\s])/
+      },
+    ],
+
+    // Custom token for #pragma's
+    'pragma': {
+      pattern: /#pragma(.*);/,
+      inside: {
+        'keyword': /(?:#pragma|test-version-set|not-version|version|allow-post-modification|compute-asm-ltr)\b/,
+        'number': /(?:\d+)(?:.\d+)?(?:.\d+)?/,
+        'operator': /=|\^|<=|>=|<|>/,
+        'string': string,
+        'punctuation': /;/,
+      }
+    },
+
+    // Custom token for #include's
+    'include': {
+      pattern: /#include(.*);/,
+      inside: {
+        'keyword': /#include\b/,
+        'string': string,
+        'punctuation': /;/,
+      }
+    },
+
+    // builtin types
+    'builtin': /\b(?:int|cell|slice|builder|cont|tuple|type)\b/,
+
+    // builtin constants
+    'boolean': /\b(?:false|true|nil|Nil)\b/,
+
+    'keyword': /\b(?:forall|extern|global|asm|impure|inline_ref|inline|auto_apply|method_id|operator|infixl|infixr|infix|const|return|var|repeat|do|while|until|try|catch|ifnot|if|then|elseifnot|elseif|else)\b/,
+
+    'number': number,
+
+    'string': string,
+
+    'operator': operator,
+
+    'punctuation': [/[\.,;\(\)\[\]]/, /[\{\}](?![^\.~,;\[\]\(\)\s])/],
+
+    // Function and method names in declarations, definitions and calls
+    'function': [
+      { // quoted
+        pattern: new RegExp(var_identifier[0].source + /(?=\s*\()/.source),
+        greedy: true,
+      },
+      { // bitwise not operator
+        pattern: /~_/,
+        greedy: true,
+      },
+      { // remaining operators
+        pattern: new RegExp(/\^?_/.source + operator.source + /_/.source),
+        greedy: true,
+      },
+      { // plain function or method name
+        pattern: new RegExp(/[\.~]?/.source + var_identifier[1].source + /(?=\s*\()/.source),
+        greedy: true,
+      },
+      { // builtin functions and methods
+        pattern: /\b(?:divmod|moddiv|muldiv|muldivr|muldivc|muldivmod|null\?|throw|throw_if|throw_unless|throw_arg|throw_arg_if|throw_arg_unless|load_int|load_uint|preload_int|preload_uint|store_int|store_uint|load_bits|preload_bits|int_at|cell_at|slice_at|tuple_at|at|touch|touch2|run_method0|run_method1|run_method2|run_method3|~divmod|~moddiv|~store_int|~store_uint|~touch|~touch2|~dump|~stdump)\b/,
+        greedy: true,
+      },
+    ],
+
+    // Parametric polymorphism
+    'class-name': /[A-Z][^\.~,;\[\]\(\)\s]*/,
+
+    // All the rest of identifiers
+    'variable': var_identifier.map(x => { return { pattern: x, greedy: true } }),
+  };
+
+  // Adding a fc alias
+  Prism.languages.fc = Prism.languages.func;
+}(Prism));

--- a/src/theme/prism-include-languages.ts
+++ b/src/theme/prism-include-languages.ts
@@ -1,0 +1,32 @@
+import siteConfig from '@generated/docusaurus.config';
+import type * as PrismNamespace from 'prismjs';
+import type {Optional} from 'utility-types';
+
+export default function prismIncludeLanguages(
+  PrismObject: typeof PrismNamespace,
+): void {
+  const {
+    themeConfig: {prism},
+  } = siteConfig;
+  const {additionalLanguages} = prism as {additionalLanguages: string[]};
+
+  // Prism components work on the Prism instance on the window, while prism-
+  // react-renderer uses its own Prism instance. We temporarily mount the
+  // instance onto window, import components to enhance it, then remove it to
+  // avoid polluting global namespace.
+  // You can mutate PrismObject: registering plugins, deleting languages... As
+  // long as you don't re-assign it
+  globalThis.Prism = PrismObject;
+
+  additionalLanguages.forEach((lang) => {
+    // eslint-disable-next-line global-require, import/no-dynamic-require
+    require(`prismjs/components/prism-${lang}`);
+  });
+
+  // eslint-disable-next-line global-require
+  require('./prism-tact');
+  // eslint-disable-next-line global-require
+  require('./prism-func');
+
+  delete (globalThis as Optional<typeof globalThis, 'Prism'>).Prism;
+}

--- a/src/theme/prism-tact.js
+++ b/src/theme/prism-tact.js
@@ -1,0 +1,171 @@
+/**
+ * @file Prism.js definition for Tact
+ * @link https://tact-lang.org
+ * @version 1.5.0
+ * @author Novus Nota (https://github.com/novusnota)
+ * @license MIT
+ */
+(function(Prism) {
+  Prism.languages.tact = {
+    // reserved keywords
+    'keyword': [
+      {
+        pattern: /\b(?:abstract|asm|as|catch|const|contract(?!:)|do|else|extend|extends|foreach|fun|get|if|in|import|initOf|inline|let|message(?!:)|mutates|native|override|primitive|public|repeat|return|self|struct(?!:)|trait(?!:)|try|until|virtual|while|with)\b/,
+      },
+      { // reserved function names
+        pattern: /\b(?:bounced|external|init|receive)\b(?=\()/
+      },
+    ],
+
+    // built-in types
+    'builtin': [
+      {
+        pattern: /\b(?:Address|Bool|Builder|Cell|Int|Slice|String|StringBuilder)\b/,
+      },
+      { // keyword after as, see: https://prismjs.com/extending.html#object-notation
+        pattern: /(\bas\s+)(?:coins|remaining|bytes32|bytes64|int257|u?int(?:2[0-5][0-6]|1[0-9][0-9]|[1-9][0-9]?))\b/,
+        lookbehind: true,
+        greedy: true,
+      },
+    ],
+
+    // SCREAMING_SNAKE_CASE for null values and names of constants
+    'constant': [
+      {
+        pattern: /\bnull\b/,
+      },
+      {
+        pattern: /\b[A-Z][A-Z0-9_]*\b/,
+      },
+    ],
+
+    // UpperCamelCase for names of contracts, traits, structs, messages
+    'class-name': {
+      pattern: /\b[A-Z]\w*\b/,
+    },
+
+    // mappings to FunC
+    'attribute': [
+      { // functions
+        pattern: /@name/,
+        inside: {
+          'function': /.+/,
+        },
+      },
+      { // contract interfaces
+        pattern: /@interface/,
+        inside: {
+          'function': /.+/,
+        }
+      }
+    ],
+
+    'function': {
+      pattern: /\b\w+(?=\()/,
+    },
+
+    'boolean': {
+      pattern: /\b(?:false|true)\b/,
+    },
+
+    'number': [
+      { // hexadecimal, case-insensitive /i
+        pattern: /\b0x[0-9a-f](?:_?[0-9a-f])*\b/i,
+      },
+      { // octal, case-insensitive /i
+        pattern: /\b0o[0-7](?:_?[0-7])*\b/i,
+      },
+      { // binary, case-insensitive /i
+        pattern: /\b0b[01](?:_?[01])*\b/i,
+      },
+      { // decimal integers, starting with 0
+        pattern: /\b0\d*\b/,
+      },
+      { // other decimal integers
+        pattern: /\b[1-9](?:_?\d)*\b/,
+      },
+    ],
+
+    'string': undefined,
+
+    'punctuation': {
+      pattern: /[{}[\]();,.:?]/,
+    },
+
+    'comment': [
+      { // single-line
+        pattern: /(^|[^\\:])\/\/.*/,
+        lookbehind: true,
+        greedy: true,
+      },
+      { // multi-line
+        pattern: /(^|[^\\])\/\*[\s\S]*?(?:\*\/|$)/,
+        lookbehind: true,
+        greedy: true,
+      },
+      {
+        // unused variable identifier
+        pattern: /\b_\b/
+      }
+    ],
+
+    'operator': {
+      'pattern': /![!=]?|->|[+\-*/%=]=?|[<>]=|<<?|>>?|~|\|[\|=]?|&[&=]?|\^=?/,
+    },
+
+    'variable': {
+      'pattern': /\b[a-zA-Z_]\w*\b/,
+    },
+
+  };
+
+  // strings, made this way to not collide with other entities
+  Prism.languages.insertBefore('tact', 'string', {
+    'string-literal': {
+      pattern: /(?:(")(?:\\.|(?!\1)[^\\\r\n])*\1(?!\1))/,
+      greedy: true,
+      inside: {
+        'regex': [
+          { // \\ \" \n \r \t \v \b \f
+            pattern: /\\[\\"nrtvbf]/,
+          },
+          { // hexEscape, \x00 through \xFF
+            pattern: /\\x[0-9a-fA-F]{2}/,
+          },
+          { // unicodeEscape, \u0000 through \uFFFF
+            pattern: /\\u[0-9a-fA-F]{4}/,
+          },
+          { // unicodeCodePoint, \u{0} through \u{FFFFFF}
+            pattern: /\\u\{[0-9a-fA-F]{1,6}\}/,
+          },
+        ],
+        'string': {
+          pattern: /[\s\S]+/,
+        },
+      },
+    },
+  });
+
+  // map and bounced message generic type modifiers
+  Prism.languages.insertBefore('tact', 'keyword', {
+    'generics': {
+      pattern: /(?:\b(?:bounced|map)\b<[^\\\r\n]*>)/,
+      greedy: true,
+      inside: {
+        'builtin': [
+          ...Prism.languages['tact']['builtin'],
+          {
+            pattern: /\b(?:bounced(?=<)|map(?=<))\b/
+          },
+        ],
+        'class-name': Prism.languages['tact']['class-name'],
+        'punctuation': {
+          pattern: /[<>(),.?]/,
+        },
+        'keyword': {
+          pattern: /\bas\b/,
+        },
+      },
+    },
+  });
+}(Prism));


### PR DESCRIPTION
Closes #11

I also took the liberty of changing the highlighting of the dark theme to One Dark, because the Tact Docs and Nujan IDE use it. And also because it doesn't utilize the same colours for different entities as often as the current one here (Dracula).

Still looks a bit noisy, but colors can be adjusted furthermore if needed. I'd make `variable` capture look white there, perhaps (see [this](https://github.com/ton-community/ton-docs/blob/main/prism-theme.js) and [this](https://github.com/ton-community/ton-docs/blob/e1c74834cc5df5ef07dbe6b68ee3f52b3e06c677/docusaurus.config.js#L510-L522) for a "how-to"):

![image](https://github.com/user-attachments/assets/dcd48298-84b7-4c96-bfd4-4febb0372d5c)
